### PR TITLE
Fix bug which append email addresses to infinity

### DIFF
--- a/app/src/main/java/de/wikilab/android/ldapsync/platform/ContactMerger.java
+++ b/app/src/main/java/de/wikilab/android/ldapsync/platform/ContactMerger.java
@@ -103,7 +103,7 @@ public class ContactMerger {
 
         ops.add(ContentProviderOperation
                 .newDelete(addCallerIsSyncAdapterFlag(Data.CONTENT_URI))
-                .withSelection( selection, new String[] { rawContactId + "", }).build());
+                .withSelection( selection, new String[] { rawContactId + "", Email.CONTENT_ITEM_TYPE}).build());
 
         if (newMails == null) return;
 


### PR DESCRIPTION
This pr fixes the bug which appended email addresses to infinity to contact. It happened because the deletion did not work.