### PR TITLE
Add support for CommonDataKinds.Nickname synchronization.

### DIFF
--- a/app/src/main/java/de/wikilab/android/ldapsync/client/Contact.java
+++ b/app/src/main/java/de/wikilab/android/ldapsync/client/Contact.java
@@ -35,6 +35,7 @@ public class Contact {
 	private String dn = "";
 	private String firstName = "";
 	private String lastName = "";
+	private String nickname = "";
 	private String cellWorkPhone = "";
 	private String workPhone = "";
 	private String homePhone = "";
@@ -62,8 +63,16 @@ public class Contact {
 		return lastName;
 	}
 
+	public String getNickname() {
+		return nickname;
+	}
+
 	public void setLastName(String lastName) {
 		this.lastName = lastName;
+	}
+
+	public void setNickname(String nickname) {
+		this.nickname = nickname;
 	}
 
 	public void setCellWorkPhone(String cellWorkPhone) {
@@ -132,6 +141,7 @@ public class Contact {
 			if (getAttributevalue(user, preferences, "last_name") == null || getAttributevalue(user, preferences, "first_name") == null) {
 				return null;
 			}
+			c.setNickname(getAttributevalue(user, preferences, "nickname"));
 			c.setWorkPhone(getAttributevalue(user, preferences, "office_phone"));
 			c.setCellWorkPhone(getAttributevalue(user, preferences, "cell_phone"));
 			c.setHomePhone(getAttributevalue(user, preferences, "home_phone"));

--- a/app/src/main/java/de/wikilab/android/ldapsync/platform/ContactManager.java
+++ b/app/src/main/java/de/wikilab/android/ldapsync/platform/ContactManager.java
@@ -41,6 +41,7 @@ import android.provider.ContactsContract.Groups;
 import android.provider.ContactsContract.RawContacts;
 import android.provider.ContactsContract.Settings;
 import android.provider.ContactsContract.CommonDataKinds.Email;
+import android.provider.ContactsContract.CommonDataKinds.Nickname;
 import android.provider.ContactsContract.CommonDataKinds.Phone;
 import android.provider.ContactsContract.CommonDataKinds.Photo;
 import android.provider.ContactsContract.CommonDataKinds.StructuredName;
@@ -117,6 +118,8 @@ public class ContactManager {
 					//existingContact.setDisplayName(c.getString(c.getColumnIndex(Data.DATA1)));
 					existingContact.setFirstName(c.getString(c.getColumnIndex(Data.DATA2)));
 					existingContact.setLastName(c.getString(c.getColumnIndex(Data.DATA3)));
+				} else if (mimetype.equals(Nickname.CONTENT_ITEM_TYPE)) {
+					existingContact.setNickname(c.getString(c.getColumnIndex(Data.DATA1)));
 				} else if (mimetype.equals(Email.CONTENT_ITEM_TYPE)) {
 					int type = c.getInt(c.getColumnIndex(Data.DATA2));
 					if (type == Email.TYPE_WORK) {
@@ -212,6 +215,8 @@ public class ContactManager {
 					if (mimetype.equals(StructuredName.CONTENT_ITEM_TYPE)) {
 						existingContact.setFirstName(c.getString(c.getColumnIndex(Data.DATA2)));
 						existingContact.setLastName(c.getString(c.getColumnIndex(Data.DATA3)));
+					} else if (mimetype.equals(Nickname.CONTENT_ITEM_TYPE)) {
+						existingContact.setNickname(c.getString(c.getColumnIndex(Data.DATA1)));
 					} else if (mimetype.equals(Email.CONTENT_ITEM_TYPE)) {
 						int type = c.getInt(c.getColumnIndex(Data.DATA2));
 						if (type == Email.TYPE_WORK) {
@@ -335,6 +340,7 @@ public class ContactManager {
 	private void prepareFields(long rawContactId, Contact newC, Contact existingC, ArrayList<ContentProviderOperation> ops, boolean isNew) {
 		ContactMerger contactMerger = new ContactMerger(rawContactId, newC, existingC, ops, l);
 		contactMerger.updateName();
+		contactMerger.updateNickname();
 		contactMerger.updateMail(Email.TYPE_WORK);
 
 		contactMerger.updatePhone(Phone.TYPE_WORK_MOBILE);

--- a/app/src/main/java/de/wikilab/android/ldapsync/platform/ContactMerger.java
+++ b/app/src/main/java/de/wikilab/android/ldapsync/platform/ContactMerger.java
@@ -26,6 +26,7 @@ import android.net.Uri;
 import android.provider.ContactsContract;
 import android.provider.ContactsContract.Data;
 import android.provider.ContactsContract.CommonDataKinds.Email;
+import android.provider.ContactsContract.CommonDataKinds.Nickname;
 import android.provider.ContactsContract.CommonDataKinds.Phone;
 import android.provider.ContactsContract.CommonDataKinds.Photo;
 import android.provider.ContactsContract.CommonDataKinds.StructuredName;
@@ -73,6 +74,27 @@ public class ContactMerger {
 			Builder updateOp = ContentProviderOperation.newUpdate(addCallerIsSyncAdapterFlag(Data.CONTENT_URI)).withSelection(
 					Data.RAW_CONTACT_ID + "=? AND " + Data.MIMETYPE + "=?", new String[] { rawContactId + "", StructuredName.CONTENT_ITEM_TYPE })
 					.withValues(cv);
+			ops.add(updateOp.build());
+		}
+	}
+
+	public void updateNickname() {
+		String selection = Data.RAW_CONTACT_ID + "=? AND " + Nickname.MIMETYPE + "=?";
+		if (TextUtils.isEmpty(newC.getNickname()) && !TextUtils.isEmpty(existingC.getNickname())) {
+			l.d("Delete nickname (" + existingC.getNickname() + ")");
+			ops.add(ContentProviderOperation.newDelete(addCallerIsSyncAdapterFlag(Data.CONTENT_URI)).withSelection(selection,
+					new String[] { rawContactId + "", Nickname.CONTENT_ITEM_TYPE }).build());
+		} else if (!TextUtils.isEmpty(newC.getNickname()) && TextUtils.isEmpty(existingC.getNickname())) {
+			l.d("Add nickname (" + newC.getNickname() + ")");
+			ContentValues cv = new ContentValues();
+			cv.put(Nickname.NAME, newC.getNickname());
+			cv.put(Nickname.MIMETYPE, Nickname.CONTENT_ITEM_TYPE);
+			Builder insertOp = createInsert(rawContactId, cv);
+			ops.add(insertOp.build());
+		} else if (!TextUtils.isEmpty(newC.getNickname()) && !newC.getNickname().equals(existingC.getNickname())) {
+			l.d("Update nickname (" + existingC.getNickname() + " => " + newC.getNickname() + ")");
+			Builder updateOp = ContentProviderOperation.newUpdate(addCallerIsSyncAdapterFlag(Data.CONTENT_URI)).withSelection(selection,
+					new String[] { rawContactId + "", Nickname.CONTENT_ITEM_TYPE }).withValue(Nickname.NAME, newC.getNickname());
 			ops.add(updateOp.build());
 		}
 	}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -38,6 +38,7 @@
 	<string name="login_activity_ldap_mappings_label">LDAP Zuordnungen</string>
 	<string name="login_activity_firstname_label">Vorname</string>
 	<string name="login_activity_lastname_label">Nachname</string>
+	<string name="login_activity_nickname_label">Spitzname</string>
 	<string name="login_activity_officephone_label">Geschäftsnummer</string>
 	<string name="login_activity_cellphone_label">Mobilnummer</string>
 	<string name="login_activity_homephone_label">Heimnummer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="login_activity_ldap_mappings_label">LDAP Mappings</string>
     <string name="login_activity_firstname_label">First Name</string>
     <string name="login_activity_lastname_label">Last Name</string>
+    <string name="login_activity_nickname_label">Nickname</string>
     <string name="login_activity_officephone_label">Office Phone</string>
     <string name="login_activity_cellphone_label">Cell Phone</string>
     <string name="login_activity_homephone_label">Home Phone</string>

--- a/app/src/main/res/xml/preference_resources.xml
+++ b/app/src/main/res/xml/preference_resources.xml
@@ -26,6 +26,10 @@
                 android:key="last_name"
                 android:title="Last Name"/>
         <EditTextPreference
+                android:defaultValue=""
+                android:key="nickname"
+                android:title="Nickname"/>
+        <EditTextPreference
                 android:defaultValue="telephonenumber"
                 android:key="office_phone"
                 android:title="Office Phone"/>


### PR DESCRIPTION
There is no corresponding attribute in the default objectClass
inetOrgPerson, so the default mapping is left blank, but there are
corresponding attributes in many other commonly used objectClass'es,
eg. attribute eduPersonNickname in objectClass eduPerson.